### PR TITLE
DS-646 Padding between modules

### DIFF
--- a/components/Modules/VsBrArticleModule.vue
+++ b/components/Modules/VsBrArticleModule.vue
@@ -1,6 +1,7 @@
 <template>
     <VsModuleWrapper
         business-support
+        class="py-0"
         :theme="module.themeValue"
     >
         <VsArticle


### PR DESCRIPTION
Remove padding from module wrapper within the article module, this is to make spacing between modules consistent.