### PR TITLE
fix(forms): switch to camel case for submit url

### DIFF
--- a/components/Modules/VsBrForm.vue
+++ b/components/Modules/VsBrForm.vue
@@ -13,7 +13,7 @@
                     :is-marketo="module.config.type === 'marketo'"
                     :marketo-instance="module.config.marketoInstance ? module.config.marketoInstance : ''"
                     :munchkin-id="module.config.munchkinId ? module.config.munchkinId : ''"
-                    :submit-url="module.config.submitURL"
+                    :submit-url="module.config.submitUrl"
                     :data-url="module.config.jsonUrl"
                     :messaging-url="configStore.getLabel('forms', 'form.messaging-url')"
                     :country-list-url="configStore.getLabel('forms', 'form.country-url')"


### PR DESCRIPTION
There was an inconsistency between how the data was returned for fepl and breg, leading to this being set up as submitURL. That should now consistently be cased like this for all configs, and this fixes the form for https://visitscotland.atlassian.net/browse/DS-677