### PR TITLE
fix(styles in multiple sfcs): override whitespace baked into CL compo…

### DIFF
--- a/components/Modules/VsBrArticleModule.vue
+++ b/components/Modules/VsBrArticleModule.vue
@@ -118,3 +118,20 @@ for (let x = 0; x < module.sections.length; x++) {
     articleSections.push(nextSection);
 }
 </script>
+
+<style lang="scss">
+    .vs-article {
+        &__header {
+            margin-top: 0 !important;
+        }
+
+        &__wrapper {
+            margin-bottom: 0 !important;
+        }
+
+        &-section {
+            margin-bottom: 0 !important;
+        }
+    }
+
+</style>

--- a/components/Modules/VsBrBreadcrumb.vue
+++ b/components/Modules/VsBrBreadcrumb.vue
@@ -72,3 +72,9 @@ useJsonld({
     itemListElement: itemList,
 });
 </script>
+
+<style lang="scss">
+    .vs-page-intro__breadcrumb {
+        margin-top: 0 !important;
+    }
+</style>

--- a/components/Modules/VsBrModuleBuilder.vue
+++ b/components/Modules/VsBrModuleBuilder.vue
@@ -188,3 +188,10 @@ if (modules) {
     }
 }
 </script>
+
+<style lang="scss">
+    .vs-module-wrapper {
+        padding-top: 3rem !important;
+        padding-bottom: 3.5rem !important;
+    }
+</style>

--- a/components/Modules/VsBrPageIntro.vue
+++ b/components/Modules/VsBrPageIntro.vue
@@ -169,3 +169,12 @@ if (page) {
     }
 }
 </script>
+
+<style lang="scss">
+    .vs-page-intro__wrapper {
+
+        >.container {
+            padding-bottom: 0;
+        }
+    }
+</style>


### PR DESCRIPTION
…nents

A lot of the CL's content modules come with peripheral whietspace included. This stacks on BSH layout modules to make spacing unpredictable. This change is a 'reset' that provides a consistent basis for further iterations.

This is phase one of a multi-stage process to rationalise the distribution of whitespace across components at the page level. 
At the moment it's coming from a lot of different places in the CL:

- wrapper components that supply padding / margin, sometimes nested 
- internal subcomponents like headings that have arbitrary `margin-top`
- relational selectors that target classes _inside_ wrappers
- utility classes in the CL component markup

I'm not 100% sure these changes will work for BSH in a deployment build because the CSS specificity might not be the same as in a dev environment, but if they do it's a step towards solving the immediate issues. Follow-up will be to refactor the CL components in stages: 

1.1 move relational rules (like `wrapper > .container`) into semantic classes 
1.2 relocate spacing rules from child to parent elements, eg from `.vs-article__header { margin-top: 3rem }` to `.vs-article { padding-top: 3rem }` 
1.3 remove utility classes in favour of semantic class rules to lower specificity of the overrides

These are not expected to be breaking changes. The next phase would involve systematically removing all peripheral whitespace from CL components and consolidating it in consistent layout components like wrappers that can be used predictably across products. 

