### PR TITLE
fix(gtm): add check for client as well as preview to block GTM load in preview mode

### DIFF
--- a/components/Modules/VsBrGtm.vue
+++ b/components/Modules/VsBrGtm.vue
@@ -39,7 +39,7 @@ if (page && page.isPreview()) {
     isPreviewMode = true;
 }
 
-if (id && !isPreviewMode) {
+if (id && !isPreviewMode && import.meta.client) {
     useHead({
         script: [
             `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
Turns out that just checking for preview doesn't work here, as it returns false in SSR and the SSR mode then parses the GTM tag into all its constituent scripts and effectively loads it anyway. Shouldn't be any reason we need it server-side so hopefully this gets it