### PR TITLE
fix(meganave wrapper): move cludo search script from global to component

### DIFF
--- a/components/Modules/VsBrMegaNav.vue
+++ b/components/Modules/VsBrMegaNav.vue
@@ -83,6 +83,7 @@
 </template>
 
 <script lang="ts" setup>
+import { useScript } from '#imports';
 
 import {
     VsMegaNavDropdownContainer,
@@ -97,6 +98,10 @@ import VsBrMegaNavFeaturedItem from '~/components/Modules/VsBrMegaNavFeaturedIte
 const props = defineProps<{ links: any[] }>();
 const links: any = props.links;
 
+const { load } = useScript('https://customer.cludo.com/scripts/bundles/search-script.min.js', {
+  trigger: 'manual'
+});
+load();
 </script>
 
 <style lang="scss">

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,7 +15,6 @@ const clVersion = bufferFile('.clversion');
 export default defineNuxtConfig({
     scripts: {
         globals: {
-            search: 'https://customer.cludo.com/scripts/bundles/search-script.min.js',
             results: '/scripts/cludo-search-results.js',
         },
     },


### PR DESCRIPTION
script attaches to the rendered site search input from meganav and was not synced to it being loaded in the document as a global