### PR TITLE
fix(megalinks module): counteract media query in the library component

### DIFF
--- a/components/Modules/VsBrMegalinksMultiImageModule.vue
+++ b/components/Modules/VsBrMegalinksMultiImageModule.vue
@@ -299,7 +299,7 @@ const getLgSize = (index: number, linksLength: number) => {
 
 </script>
 
-<style>
+<style lang="scss">
     div.multi-image-links-module {
         span {
             display: block;


### PR DESCRIPTION
The component adds 6rem top padding > 992 to fit with a dot-com design combination. This is not compatible with the BSH page layout