### PR TITLE
fix(vsbrmain): adds title suffix brand name to site title and meta tag

### DIFF
--- a/components/Base/VsBrMain.vue
+++ b/components/Base/VsBrMain.vue
@@ -130,11 +130,11 @@ if (page.value) {
     const runtimeConfig = useRuntimeConfig();
 
     useHead({
-        title: document.model.data.seoTitle,
+        title: `${document.model.data.seoTitle} ${configStore.getLabel('seo', 'title-suffix')}`,
         meta: [
             {
                 name: 'title',
-                content: document.model.data.seoTitle,
+                content: `${document.model.data.seoTitle} ${configStore.getLabel('seo', 'title-suffix')}`,
             },
             {
                 name: 'description',


### PR DESCRIPTION
Same change as made in [visitscotland/business-events-front-end PR#309](https://github.com/visitscotland/business-events-front-end/pull/309) and [visitscotland/nuxt-bloomreach-sdk-starter PR#8](https://github.com/visitscotland/nuxt-bloomreach-sdk-starter/pull/8)