### PR TITLE
Bshub 830 featured webinar content test

### DIFF
--- a/components/Modules/VsBrEventListingModule.vue
+++ b/components/Modules/VsBrEventListingModule.vue
@@ -1,15 +1,62 @@
 <template>
-    <VsTabs
-        class="my-400 vs-events-listing"
-        :id="moduleId"
-        no-container
-        data-event-listing="True"
-    >
-        <VsTabItem
-            v-for="(eventList, index) in module.eventsListings"
-            :key="index"
-            :title="eventList.title"
-        >
+
+    <section class="vs-rich-text-wrapper featured">
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <h2 class="vs-heading vs-heading--heading-xl">Featured webinar</h2>
+                    <VsEventCard
+                        :cta-label="featuredEvent.cta.label"
+                        :cta-href="featuredEvent.cta.link"
+                        :key="featuredEvent.title"
+                        :data-event-listing="True">
+                        <template #event-card-header>
+                            {{ featuredEvent.title }}
+                        </template>
+
+                        <template #event-card-date>
+                            {{ featuredEvent.dates }}
+                        </template>
+
+                        <template #event-card-content>
+                            <VsBrRichText :input-content="featuredEvent.summary" />
+
+                            <VsList unstyled>
+                                <VsRow>
+                                    <VsCol
+                                        cols="2"
+                                        md="4">
+                                        <li>
+                                            <strong>Time:</strong> {{ featuredEvent.times }}
+                                        </li>
+                                        <li>
+                                            <strong>Price:</strong> Free
+                                        </li>
+                                        <li>
+                                            <strong>Location:</strong> Online
+                                        </li>
+                                    </VsCol>
+
+                                    <VsCol
+                                           cols="12"
+                                           md="4">
+                                        <li>
+                                            <strong>Organiser:</strong> VisitScotland
+                                        </li>
+                                    </VsCol>
+                                </VsRow>
+                            </VsList>
+                        </template>
+                    </VsEventCard>
+
+                </div>
+            </div>
+        </div>
+        </section>
+
+
+    <VsTabs class="my-400 vs-events-listing" :id="moduleId" no-container data-event-listing="True">
+        <VsTabItem v-for="(eventList, index) in module.eventsListings" :key="index" :title="eventList.title">
             <VsContainer class="mt-300">
                 <VsRow>
                     <VsHeading
@@ -49,6 +96,7 @@ import {
     VsTabItem,
     VsRow,
     VsWarning,
+    VsEventCard,
 } from '@visitscotland/component-library/components';
 import useConfigStore from '~/stores/configStore.ts';
 import VsBrRichText from './VsBrRichText.vue';
@@ -60,11 +108,38 @@ const props = defineProps<{
 
 const configStore = useConfigStore();
 const module: any = props.module;
+const featuredEvent = {
+    "hippoBean": null,
+    "anchor": null,
+    "errorMessages": null,
+    "marketoId": null,
+    "title": "VisitScotland bitesize webinars: start working with online travel agents",
+    "summary": "<p>Discover how an online travel agent (OTA) can increase bookings and profitability without detracting from direct bookings. Get practical tips on how to create an OTA listing and how to manage your relationship with an OTA.</p>\n\n<p>For tourism experiences (tours, visitor attractions and activity providers) that want to use OTAs for the first time.</p>",
+    "dates": "22 May, 2025",
+    "times": "14:00 - 14:30",
+    "price": "Free",
+    "location": "Online",
+    "organiser": "VisitScotland",
+    "contact": null,
+    "registrationDeadline": null,
+    "cta": {
+        "label": "Find out more",
+        "link": "https://visitscotland.eventsair.com/2025-2026-business-development-programme/registration-webinars/Site/Register",
+        "type": "EXTERNAL"
+    },
+    "type": "EventCard"
+};
 
 const moduleId = computed(() => module.anchor || 'events-listing-module');
 </script>
 
 <style lang="scss">
+
+.featured {
+    .vs-event-card {
+        border: 1px solid rgb(233,233,233);
+    }
+}
 .vs-tabs--no-container .tab-pane .vs-heading {
     display: block !important;
 

--- a/components/Modules/VsBrEventListingModule.vue
+++ b/components/Modules/VsBrEventListingModule.vue
@@ -1,10 +1,63 @@
 <template>
-    <VsTabs
-        class="my-400 vs-events-listing"
-        :id="moduleId"
-        no-container
-        data-event-listing="True"
-    >
+    <section class="vs-rich-text-wrapper featured">
+        <div class="container">
+            <div class="row">
+                <div class="col-12">
+                    <h2 class="vs-heading vs-heading--heading-xl">
+                        Featured webinar
+                    </h2>
+                    <VsEventCard
+                        :cta-label="featuredEvent.cta.label"
+                        :cta-href="featuredEvent.cta.link"
+                        :key="featuredEvent.title"
+                        :data-event-listing="True"
+                    >
+                        <template #event-card-header>
+                            {{ featuredEvent.title }}
+                        </template>
+
+                        <template #event-card-date>
+                            {{ featuredEvent.dates }}
+                        </template>
+
+                        <template #event-card-content>
+                            <VsBrRichText :input-content="featuredEvent.summary" />
+
+                            <VsList unstyled>
+                                <VsRow>
+                                    <VsCol
+                                        cols="2"
+                                        md="4"
+                                    >
+                                        <li>
+                                            <strong>Time:</strong> {{ featuredEvent.times }}
+                                        </li>
+                                        <li>
+                                            <strong>Price:</strong> Free
+                                        </li>
+                                        <li>
+                                            <strong>Location:</strong> Online
+                                        </li>
+                                    </VsCol>
+
+                                    <VsCol
+                                        cols="12"
+                                        md="4"
+                                    >
+                                        <li>
+                                            <strong>Organiser:</strong> VisitScotland
+                                        </li>
+                                    </VsCol>
+                                </VsRow>
+                            </VsList>
+                        </template>
+                    </VsEventCard>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <VsTabs class="my-400 vs-events-listing" :id="moduleId" no-container data-event-listing="True">
         <VsTabItem
             v-for="(eventList, index) in module.eventsListings"
             :key="index"
@@ -12,72 +65,19 @@
         >
             <VsContainer class="mt-300">
                 <VsRow>
-                    <section class="vs-rich-text-wrapper featured">
-                        <div class="container">
-                            <div class="row">
-                                <div class="col-12">
-                                    <h2 class="vs-heading vs-heading--heading-xl">
-                                        Featured webinar
-                                    </h2>
-                                    <VsEventCard
-                                        :cta-label="featuredEvent.cta.label"
-                                        :cta-href="featuredEvent.cta.link"
-                                        :key="featuredEvent.title"
-                                        :data-event-listing="True"
-                                    >
-                                        <template #event-card-header>
-                                            {{ featuredEvent.title }}
-                                        </template>
-
-                                        <template #event-card-date>
-                                            {{ featuredEvent.dates }}
-                                        </template>
-
-                                        <template #event-card-content>
-                                            <VsBrRichText :input-content="featuredEvent.summary" />
-
-                                            <VsList unstyled>
-                                                <VsRow>
-                                                    <VsCol
-                                                        cols="2"
-                                                        md="4"
-                                                    >
-                                                        <li>
-                                                            <strong>Time: </strong>
-                                                            {{ featuredEvent.times }}
-                                                        </li>
-                                                        <li>
-                                                            <strong>Price:</strong> Free
-                                                        </li>
-                                                        <li>
-                                                            <strong>Location:</strong> Online
-                                                        </li>
-                                                    </VsCol>
-
-                                                    <VsCol
-                                                        cols="12"
-                                                        md="4"
-                                                    >
-                                                        <li>
-                                                            <strong>Organiser: </strong>
-                                                            VisitScotland
-                                                        </li>
-                                                    </VsCol>
-                                                </VsRow>
-                                            </VsList>
-                                        </template>
-                                    </VsEventCard>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-                    <VsHeading level="3" heading-style="heading-m">
+                    <VsHeading
+                        level="3"
+                        heading-style="heading-m"
+                    >
                         {{ eventList.title }}
                     </VsHeading>
 
                     <VsBrRichText :input-content="eventList.copy.value" />
                 </VsRow>
-                <VsBrEventListing :event-data="eventList" :module-id="moduleId" />
+                <VsBrEventListing
+                    :event-data="eventList"
+                    :module-id="moduleId"
+                />
             </VsContainer>
         </VsTabItem>
     </VsTabs>
@@ -141,12 +141,12 @@ const moduleId = computed(() => module.anchor || 'events-listing-module');
 </script>
 
 <style lang="scss">
+
 .featured {
     .vs-event-card {
-        border: 1px solid rgb(233, 233, 233);
+        border: 1px solid rgb(233,233,233);
     }
 }
-
 .vs-tabs--no-container .tab-pane .vs-heading {
     display: block !important;
 

--- a/components/Modules/VsBrEventListingModule.vue
+++ b/components/Modules/VsBrEventListingModule.vue
@@ -1,77 +1,83 @@
 <template>
-
-    <section class="vs-rich-text-wrapper featured">
-        <div class="container">
-            <div class="row">
-                <div class="col-12">
-                    <h2 class="vs-heading vs-heading--heading-xl">Featured webinar</h2>
-                    <VsEventCard
-                        :cta-label="featuredEvent.cta.label"
-                        :cta-href="featuredEvent.cta.link"
-                        :key="featuredEvent.title"
-                        :data-event-listing="True">
-                        <template #event-card-header>
-                            {{ featuredEvent.title }}
-                        </template>
-
-                        <template #event-card-date>
-                            {{ featuredEvent.dates }}
-                        </template>
-
-                        <template #event-card-content>
-                            <VsBrRichText :input-content="featuredEvent.summary" />
-
-                            <VsList unstyled>
-                                <VsRow>
-                                    <VsCol
-                                        cols="2"
-                                        md="4">
-                                        <li>
-                                            <strong>Time:</strong> {{ featuredEvent.times }}
-                                        </li>
-                                        <li>
-                                            <strong>Price:</strong> Free
-                                        </li>
-                                        <li>
-                                            <strong>Location:</strong> Online
-                                        </li>
-                                    </VsCol>
-
-                                    <VsCol
-                                           cols="12"
-                                           md="4">
-                                        <li>
-                                            <strong>Organiser:</strong> VisitScotland
-                                        </li>
-                                    </VsCol>
-                                </VsRow>
-                            </VsList>
-                        </template>
-                    </VsEventCard>
-
-                </div>
-            </div>
-        </div>
-        </section>
-
-
-    <VsTabs class="my-400 vs-events-listing" :id="moduleId" no-container data-event-listing="True">
-        <VsTabItem v-for="(eventList, index) in module.eventsListings" :key="index" :title="eventList.title">
+    <VsTabs
+        class="my-400 vs-events-listing"
+        :id="moduleId"
+        no-container
+        data-event-listing="True"
+    >
+        <VsTabItem
+            v-for="(eventList, index) in module.eventsListings"
+            :key="index"
+            :title="eventList.title"
+        >
             <VsContainer class="mt-300">
                 <VsRow>
-                    <VsHeading
-                        level="3"
-                        heading-style="heading-m"
-                    >
+                    <section class="vs-rich-text-wrapper featured">
+                        <div class="container">
+                            <div class="row">
+                                <div class="col-12">
+                                    <h2 class="vs-heading vs-heading--heading-xl">
+                                        Featured webinar
+                                    </h2>
+                                    <VsEventCard
+                                        :cta-label="featuredEvent.cta.label"
+                                        :cta-href="featuredEvent.cta.link"
+                                        :key="featuredEvent.title"
+                                        :data-event-listing="True"
+                                    >
+                                        <template #event-card-header>
+                                            {{ featuredEvent.title }}
+                                        </template>
+
+                                        <template #event-card-date>
+                                            {{ featuredEvent.dates }}
+                                        </template>
+
+                                        <template #event-card-content>
+                                            <VsBrRichText :input-content="featuredEvent.summary" />
+
+                                            <VsList unstyled>
+                                                <VsRow>
+                                                    <VsCol
+                                                        cols="2"
+                                                        md="4"
+                                                    >
+                                                        <li>
+                                                            <strong>Time: </strong>
+                                                            {{ featuredEvent.times }}
+                                                        </li>
+                                                        <li>
+                                                            <strong>Price:</strong> Free
+                                                        </li>
+                                                        <li>
+                                                            <strong>Location:</strong> Online
+                                                        </li>
+                                                    </VsCol>
+
+                                                    <VsCol
+                                                        cols="12"
+                                                        md="4"
+                                                    >
+                                                        <li>
+                                                            <strong>Organiser: </strong>
+                                                            VisitScotland
+                                                        </li>
+                                                    </VsCol>
+                                                </VsRow>
+                                            </VsList>
+                                        </template>
+                                    </VsEventCard>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <VsHeading level="3" heading-style="heading-m">
                         {{ eventList.title }}
                     </VsHeading>
 
                     <VsBrRichText :input-content="eventList.copy.value" />
                 </VsRow>
-                <VsBrEventListing
-                    :event-data="eventList"
-                    :module-id="moduleId"
-                />
+                <VsBrEventListing :event-data="eventList" :module-id="moduleId" />
             </VsContainer>
         </VsTabItem>
     </VsTabs>
@@ -97,7 +103,7 @@ import {
     VsRow,
     VsWarning,
     VsEventCard,
-    VsList
+    VsList,
 } from '@visitscotland/component-library/components';
 import useConfigStore from '~/stores/configStore.ts';
 import VsBrRichText from './VsBrRichText.vue';
@@ -110,37 +116,37 @@ const props = defineProps<{
 const configStore = useConfigStore();
 const module: any = props.module;
 const featuredEvent = {
-    "hippoBean": null,
-    "anchor": null,
-    "errorMessages": null,
-    "marketoId": null,
-    "title": "VisitScotland bitesize webinars: The importance of the UK domestic market",
-    "summary": "<p>Discover the importance of the UK market and the performance of domestic tourism in Scotland. This session will focus on who our domestic visitors are and what motivates them to plan, book and visit. You will also hear about the future prospects for domestic tourism, current sentiment of UK residents and Scotland holiday intentions for 2025.</p>",
-    "dates": "05 June, 2025",
-    "times": "14:00 - 14:30",
-    "price": "Free",
-    "location": "Online",
-    "organiser": "VisitScotland",
-    "contact": null,
-    "registrationDeadline": null,
-    "cta": {
-        "label": "Find out more",
-        "link": "https://visitscotland.eventsair.com/2025-2026-business-development-programme/registration-webinars/Site/Register",
-        "type": "EXTERNAL"
+    hippoBean: null,
+    anchor: null,
+    errorMessages: null,
+    marketoId: null,
+    title: 'VisitScotland bitesize webinars: importance of international markets',
+    summary: '<p>International visitors are vital for your business as you broaden your reach and reduce your risk. Discover the volume and value that these international markets can bring, with practical tips on how to understand booking behaviours and reach these visitors.</p>',
+    dates: '19 June, 2025',
+    times: '14:00 - 14:30',
+    price: 'Free',
+    location: 'Online',
+    organiser: 'VisitScotland',
+    contact: null,
+    registrationDeadline: null,
+    cta: {
+        label: 'Find out more',
+        link: 'https://visitscotland.eventsair.com/2025-2026-business-development-programme/registration-webinars/Site/Register',
+        type: 'EXTERNAL',
     },
-    "type": "EventCard"
+    type: 'EventCard',
 };
 
 const moduleId = computed(() => module.anchor || 'events-listing-module');
 </script>
 
 <style lang="scss">
-
 .featured {
     .vs-event-card {
-        border: 1px solid rgb(233,233,233);
+        border: 1px solid rgb(233, 233, 233);
     }
 }
+
 .vs-tabs--no-container .tab-pane .vs-heading {
     display: block !important;
 

--- a/components/Modules/VsBrEventListingModule.vue
+++ b/components/Modules/VsBrEventListingModule.vue
@@ -97,6 +97,7 @@ import {
     VsRow,
     VsWarning,
     VsEventCard,
+    VsList
 } from '@visitscotland/component-library/components';
 import useConfigStore from '~/stores/configStore.ts';
 import VsBrRichText from './VsBrRichText.vue';
@@ -113,9 +114,9 @@ const featuredEvent = {
     "anchor": null,
     "errorMessages": null,
     "marketoId": null,
-    "title": "VisitScotland bitesize webinars: start working with online travel agents",
-    "summary": "<p>Discover how an online travel agent (OTA) can increase bookings and profitability without detracting from direct bookings. Get practical tips on how to create an OTA listing and how to manage your relationship with an OTA.</p>\n\n<p>For tourism experiences (tours, visitor attractions and activity providers) that want to use OTAs for the first time.</p>",
-    "dates": "22 May, 2025",
+    "title": "VisitScotland bitesize webinars: The importance of the UK domestic market",
+    "summary": "<p>Discover the importance of the UK market and the performance of domestic tourism in Scotland. This session will focus on who our domestic visitors are and what motivates them to plan, book and visit. You will also hear about the future prospects for domestic tourism, current sentiment of UK residents and Scotland holiday intentions for 2025.</p>",
+    "dates": "05 June, 2025",
     "times": "14:00 - 14:30",
     "price": "Free",
     "location": "Online",


### PR DESCRIPTION
@DukesColleague I've changed the event data to the webinar for 05 June. I suggest that as soon as this PR is merged we create another that reverts all the changes. After the frontend is released we can merge the reversion and then schedule another release for 5th June so that there's no possibility of the content going stale.

As you are well aware, hardcoding content into the frontend is not viable for normal operations, but this is only a small, time-limited experiment to allow us to decide how best to proceed. If you think there are any additional steps we should take to de-risk it, please let me know!