### PR TITLE
feat(chatbot): update button styles and account for icon

### DIFF
--- a/public/styles/cludo-chatbot.css
+++ b/public/styles/cludo-chatbot.css
@@ -44,11 +44,11 @@
 }
 
 .cludo-assistant-button {
-    --button-background-color: #FFFFFF !important;
-    --button-foreground-color: #1F49D6 !important;
+    --button-background-color: #1F49D6 !important;
+    --button-foreground-color: #FFFFFF !important;
     --button-outline-color: #1F49D6 !important;
-    --button-background-color--hover: #1F49D6 !important;
-    --button-foreground-color--hover: #FFFFFF !important;
+    --button-background-color--hover: #FFFFFF !important;
+    --button-foreground-color--hover: #1F49D6 !important;
 
     background-color: var(--button-background-color) !important;
     border: 2px solid var(--button-outline-color) !important;
@@ -62,6 +62,19 @@
 .cludo-assistant-button:focus {
     background-color: var(--button-background-color--hover) !important;
     color: var(--button-foreground-color--hover) !important;
+}
+
+/*
+    Cludo serves this icon as a base64 png regardless of the upload format giving us less control
+    than with an SVG. This changes the white icon to a #1F49D6 one as desired.
+ */
+
+.cludo-assistant-button:hover i {
+    filter: brightness(0) saturate(100%) invert(19%) sepia(78%) saturate(4505%) hue-rotate(229deg) brightness(87%) contrast(91%);
+}
+
+.cludo-assistant-button:focus i {
+    filter: brightness(0) saturate(100%) invert(19%) sepia(78%) saturate(4505%) hue-rotate(229deg) brightness(87%) contrast(91%);
 }
 
 .assistant-result-item__result-path {


### PR DESCRIPTION
I am not a fan of this filter solution, it works but the code is very ugly and difficult to maintain. I'm open to any suggested alternatives, the only thing that comes to mind is removing the image and adding an icon from our kit as a pseudo element but I'm not sure if that's actually something we can do without being able to add a class that fontawesome can latch onto

<img width="171" height="70" alt="image" src="https://github.com/user-attachments/assets/87989a5a-ea63-4e42-bee8-513f911aa898" />

<img width="157" height="77" alt="image" src="https://github.com/user-attachments/assets/75751f2f-66cf-44c8-b808-5cfae7049d6b" />
