### PR TITLE
feat(build): improve cl version detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",
-    "postinstall": "npm view @visitscotland/component-library version > .clversion && nuxt prepare",
+    "postinstall": "node -p \"require('./node_modules/@visitscotland/component-library/package.json').version\" > .clversion && nuxt prepare",
     "commit": "cz",
     "release:patch": "standard-version --release-as patch",
     "release:minor": "standard-version --release-as minor",


### PR DESCRIPTION
We put the version of the component library into the html for testing purposes, but `npm view` returns the latest version from the registry which isn't super helpful. This gets the current actual installed version for the same purpose.