### PR TITLE
Restore margins on events listing and adjust no-js message logic

### DIFF
--- a/components/Modules/VsBrEventListing.vue
+++ b/components/Modules/VsBrEventListing.vue
@@ -70,7 +70,7 @@
                 </div>
             </div>
 
-            <template v-if="data.results.length > 0">
+            <template v-if="data.results && data.results.length > 0">
                 <VsEventCard
                     v-for="(result, index) in data.results"
                     :cta-icon="setIcon(result.cta.type)"
@@ -88,7 +88,9 @@
                     </template>
 
                     <template #event-card-content>
-                        <VsBrRichText :input-content="result.summary" />
+                        <VsBody>
+                            <VsBrRichText :input-content="result.summary" />
+                        </VsBody>
 
                         <VsList unstyled>
                             <VsRow>
@@ -167,6 +169,7 @@ import {
     VsList,
     VsPagination,
     VsRow,
+    VsBody,
 } from '@visitscotland/component-library/components';
 import useConfigStore from '~/stores/configStore.ts';
 import VsBrRichText from './VsBrRichText.vue';

--- a/components/Modules/VsBrEventListingModule.vue
+++ b/components/Modules/VsBrEventListingModule.vue
@@ -31,7 +31,7 @@
 
     <VsContainer>
         <VsRow>
-            <VsWarning class="my-400">
+            <VsWarning class="my-400 vs-events-listing__warning">
                 {{ configStore.getLabel('events-listings-module', 'no-js') }}
             </VsWarning>
         </VsRow>
@@ -79,19 +79,17 @@ const moduleId = computed(() => module.anchor || 'events-listing-module');
     }
 }
 
-.vs-events-listing {
-    .vs-warning {
-        display: none;
-    }
+.vs-events-listing__warning {
+    display: none;
 }
 
 .no-js {
     .vs-events-listing {
         display: none;
+    }
 
-        .vs-warning {
-            display: block;
-        }
+    .vs-events-listing__warning {
+        display: block;
     }
 }
 </style>

--- a/components/Modules/VsBrEventListingModule.vue
+++ b/components/Modules/VsBrEventListingModule.vue
@@ -19,7 +19,9 @@
                         {{ eventList.title }}
                     </VsHeading>
 
-                    <VsBrRichText :input-content="eventList.copy.value" />
+                    <VsBody>
+                        <VsBrRichText :input-content="eventList.copy.value" />
+                    </VsBody>
                 </VsRow>
                 <VsBrEventListing
                     :event-data="eventList"
@@ -49,6 +51,7 @@ import {
     VsTabItem,
     VsRow,
     VsWarning,
+    VsBody,
 } from '@visitscotland/component-library/components';
 import useConfigStore from '~/stores/configStore.ts';
 import VsBrRichText from './VsBrRichText.vue';


### PR DESCRIPTION
I missed this VsBody wrapper in the V5 upgrade so some margins are currently missing

The no-js block currently shows at all times because it's been moved out of the wrapper it relies on for the style