### PR TITLE
fix(events): adjust filter button size

### DIFF
--- a/components/Modules/VsBrEventListing.vue
+++ b/components/Modules/VsBrEventListing.vue
@@ -30,7 +30,7 @@
                         v-if="selectedFilters.length > 0"
                         :rounded="false"
                         variant="primary"
-                        size="sm"
+                        size="md"
                         @click="clearAllFilters"
                     >
                         {{ configStore.getLabel('events-listings-module', 'clear-all') }}
@@ -41,7 +41,7 @@
                         :key="index"
                         :rounded="false"
                         variant="secondary"
-                        size="sm"
+                        size="md"
                         icon="fa-regular fa-xmark"
                         icon-position="right"
                         @click="removeSelectedFilter(filter.fieldId, filter.key, filter.value)"


### PR DESCRIPTION
I'm not sure if this was a knock on from v5 or from something else, but the text on these buttons was a bit out of line. They were sized as sm and getting the padding sufficient for that, but the flex layout was forcing them to the height of md buttons creating this issue. Adjusting them to md only marginally increases their width but corrects the layout.

<img width="297" height="117" alt="image" src="https://github.com/user-attachments/assets/e6055c8f-b8b0-4f02-a5f7-9bff51c36e1f" />

<img width="483" height="166" alt="image" src="https://github.com/user-attachments/assets/f154bc36-f1b1-4382-9a89-db3879304979" />

